### PR TITLE
Upgrade node version to 16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
   version:
     description: 'The version of StyLua to run'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 is being deprecated and a warning is shown on all summary pages
using stylua-action. The recommended solution is to upgrade to node 16.

More information:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
