### PR TITLE
chore: update `actions/checkout` from `v3` to `v4`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install packages
         run: |
           npm install
@@ -23,14 +23,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npm test
   # make sure the action works on a clean machine without building
   smoketest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           version: ^0.17
@@ -39,7 +39,7 @@ jobs:
   smoketest_latest_version_provided:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           version: latest

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installs the StyLua binary (from GitHub releases), and caches it. Any StyLua com
 ## Usage
 
 ```yaml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: JohnnyMorganz/stylua-action@v3
   with:
     token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the used version of [actions/checkout](https://github.com/actions/checkout) from `v3` to `v4` (currently the newest one).