### PR TITLE
Update action version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installs the StyLua binary (from GitHub releases), and caches it. Any StyLua com
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: JohnnyMorganz/stylua-action@v4
+- uses: JohnnyMorganz/stylua-action@v5
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
     version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
@@ -23,7 +23,7 @@ you can set `args: false`:
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: JohnnyMorganz/stylua-action@v4
+- uses: JohnnyMorganz/stylua-action@v5
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
     version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes


### PR DESCRIPTION
`v5` with an updated Node version seems to already be released, but I didn't realize this until inspecting tags because the README still mentions `v4`.